### PR TITLE
Update types.go to fix resizePolicy documentation for ephemeral conta…

### DIFF
--- a/staging/src/k8s.io/api/core/v1/types.go
+++ b/staging/src/k8s.io/api/core/v1/types.go
@@ -4835,6 +4835,11 @@ type EphemeralContainer struct {
 	// support namespace targeting then the result of setting this field is undefined.
 	// +optional
 	TargetContainerName string `json:"targetContainerName,omitempty" protobuf:"bytes,2,opt,name=targetContainerName"`
+	// ResizePolicy defines how the resources of a container can be resized.
+        // This field is not supported for ephemeral containers as they do not support
+        // resource requests or limits.
+        // +optional
+        ResizePolicy []ContainerResizePolicy `json:"resizePolicy,omitempty" protobuf:"bytes,14,rep,name=resizePolicy"`
 }
 
 // PodStatus represents information about the status of a pod. Status may trail the actual


### PR DESCRIPTION
What type of PR is this?
/kind documentation

What this PR does / why we need it:
This PR fixes the incorrect API documentation for the resizePolicy field in the EphemeralContainer struct. It clarifies that the resizePolicy field does not apply to ephemeral containers because they do not support resource requests or limits. These changes ensure accuracy and reduce confusion for Kubernetes users.

Which issue(s) this PR fixes:
Fixes https://github.com/kubernetes/kubernetes/issues/128384

Special notes for your reviewer:
Changes were made to the staging/src/k8s.io/api/core/v1/types.go file.
Comments were added to clarify the limitations of the resizePolicy field for ephemeral containers.
Does this PR introduce a user-facing change?

NONE
Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

NONE